### PR TITLE
Issue #58264: Remove composer version validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,9 +87,6 @@ RUN \
   apt-get autoremove -y && \
   apt-get clean all
 
-# Add composer version validation plugin.
-RUN composer global require deviantintegral/composer-gavel
-
 RUN composer --version
 
 ADD composer.json /tmp/composer.json


### PR DESCRIPTION
The gavel plugin is trying to offer to set a version, which isn't really needed - and may well be the cause of issues like https://support.computerminds.co.uk/issues/58043#note-5. We didn't use the plugin before using Composer 2, so let's stop using it now too.